### PR TITLE
Change quasars notebook kernel to python 3

### DIFF
--- a/astroquery_example_quasars.ipynb
+++ b/astroquery_example_quasars.ipynb
@@ -577,9 +577,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python (astroquery)",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "astroquery"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {


### PR DESCRIPTION
This is simply to automatically set the kernel to python 3 for the quasars notebook in binder, rather than have users select the kernel.